### PR TITLE
Adjusted Call/Subscribe to be able to serialize complex objects without syntax issues

### DIFF
--- a/Net.DDP.Client/DDPClient.cs
+++ b/Net.DDP.Client/DDPClient.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using WebSocket4Net;
 
 namespace Net.DDP.Client
 {
@@ -55,22 +56,12 @@ namespace Net.DDP.Client
             return this.GetCurrentRequestId();
         }
 
-        private string CreateJSonArray(params string[] args)
+        public WebSocketState State
         {
-            if (args == null)
-                return string.Empty;
-
-            StringBuilder argumentBuilder = new StringBuilder();
-            string delimiter=string.Empty;
-            for (int i = 0; i < args.Length; i++)
-            {
-                argumentBuilder.Append(delimiter);
-                argumentBuilder.Append(string.Format("\"{0}\"",args[i]));
-                delimiter = ",";
-            }
-
-            return argumentBuilder.ToString();
+            get { return this._connector.State; }
         }
+
+       
         private int NextId()
         {
             return _uniqueId++;

--- a/Net.DDP.Client/DDPClient.cs
+++ b/Net.DDP.Client/DDPClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -29,18 +30,28 @@ namespace Net.DDP.Client
             _connector.Connect(url);
         }
 
-        public void Call(string methodName, params string[] args)
+        public void Call(string methodName, params object[] args)
         {
-            string message = string.Format("\"msg\": \"method\",\"method\": \"{0}\",\"params\": [{1}],\"id\": \"{2}\"", methodName,this.CreateJSonArray(args), this.NextId().ToString());
-            message = "{" + message+ "}";
-            _connector.Send(message);
+            _connector.Send(JsonConvert.SerializeObject(new 
+                {
+                    msg = "method",
+                    method = methodName,
+                    @params = args,
+                    id = this.NextId().ToString()
+                }
+            ));
         }
 
-        public int Subscribe(string subscribeTo, params string[] args)
+        public int Subscribe(string subscribeTo, params object[] args)
         {
-            string message = string.Format("\"msg\": \"sub\",\"name\": \"{0}\",\"params\": [{1}],\"id\": \"{2}\"", subscribeTo,this.CreateJSonArray(args), this.NextId().ToString());
-            message = "{" + message + "}";
-            _connector.Send(message);
+            _connector.Send(JsonConvert.SerializeObject(new 
+                {
+                    msg = "sub",
+                    name = subscribeTo,
+                    @params = args,
+                    id = this.NextId().ToString()
+                }
+            ));
             return this.GetCurrentRequestId();
         }
 

--- a/Net.DDP.Client/DDPConnector.cs
+++ b/Net.DDP.Client/DDPConnector.cs
@@ -33,6 +33,11 @@ namespace Net.DDP.Client
             this._wait();
         }
 
+        public WebSocketState State
+        {
+            get { return this._socket == null ? WebSocketState.None : _socket.State; }
+        }
+
         public void Close()
         {
             _socket.Close();

--- a/Net.DDP.Client/IClient.cs
+++ b/Net.DDP.Client/IClient.cs
@@ -9,8 +9,8 @@ namespace Net.DDP.Client
     {
         void AddItem(string jsonItem);
         void Connect(string url);
-        void Call(string methodName, string[] args);
-        int Subscribe(string methodName, string[] args);
+        void Call(string methodName, object[] args);
+        int Subscribe(string methodName, object[] args);
         int GetCurrentRequestId();
     }
 }

--- a/Net.DDP.Client/Net.DDP.Client.csproj
+++ b/Net.DDP.Client/Net.DDP.Client.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\Lib\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\rep\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
I got "Discarding message with invalid JSON Object" when put to DDPClient.Call a complex object serialized with JsonConvert. So it's fixed now, additionally Newtonsoft.Json assembly is updated.
